### PR TITLE
Add apt upgrade to dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# OS Generated files.
+.DS_Store
+
+# IDE Generated files.
+.idea
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8
 
-RUN apt-get update && \
+RUN apt-get update && apt-get upgrade -y && \
     apt-get install --no-install-recommends -y curl lsb-release gnupg apt-utils && \
     curl -sS --fail -L https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -c -s) main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \


### PR DESCRIPTION
Adding in the `apt-get upgrade -y` to the Dockerfile. This along with rebuilding the container makes running subsequent `apt-get update && apt-get upgrade -y` significantly faster as must things are updated and not requiring too many things to be downloaded and unpacked within the container.