### PR TITLE
Update dependabot docker ecosystem directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     interval: daily
 
 - package-ecosystem: github-actions
-  directory: /
+  directory: /v1
+  schedule:
+    interval: daily
+- package-ecosystem: github-actions
+  directory: /v2
   schedule:
     interval: daily


### PR DESCRIPTION
This updates the directories for the docker ecosystem dependabots to make use of the new v1 and v2 directories instead.