### PR TITLE
Add fix to dependabot package ecosystems incorrect directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,15 @@
 version: 2
 updates:
-- package-ecosystem: docker
+- package-ecosystem: github-actions
   directory: /
   schedule:
     interval: daily
 
-- package-ecosystem: github-actions
+- package-ecosystem: docker
   directory: /v1
   schedule:
     interval: daily
-- package-ecosystem: github-actions
+- package-ecosystem: docker
   directory: /v2
   schedule:
     interval: daily


### PR DESCRIPTION
This fixes the directories mapped for each dependabot ecosystem. 