### PR TITLE
Update Dependabot Schedule to Weekly with Specific Time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,22 @@ updates:
 - package-ecosystem: github-actions
   directory: /
   schedule:
-    interval: daily
+    interval: weekly
+    day: "monday"
+    time: "05:00"
+    timezone: "Europe/Amsterdam"
 
 - package-ecosystem: docker
   directory: /v1
   schedule:
-    interval: daily
+    interval: weekly
+    day: "monday"
+    time: "05:00"
+    timezone: "Europe/Amsterdam"
 - package-ecosystem: docker
   directory: /v2
   schedule:
-    interval: daily
+    interval: weekly
+    day: "monday"
+    time: "05:00"
+    timezone: "Europe/Amsterdam"


### PR DESCRIPTION
This PR updates the Dependabot configuration to change the update schedule from daily to weekly. The changes include:

- Setting the update interval to weekly instead of daily.
- Configuring updates to run every Monday at 05:00 AM (Europe/Amsterdam timezone) for:
    - GitHub Actions dependencies
    - Docker dependencies in `/v1`
    - Docker dependencies in /v2

These adjustments help reduce noise from daily updates while ensuring dependencies are still updated on a regular schedule.