### PR TITLE
Fix apt-key for Trixie, pin base image, keep kubectl from apt

### DIFF
--- a/.github/workflows/scheduled-rebuild.yml
+++ b/.github/workflows/scheduled-rebuild.yml
@@ -2,8 +2,8 @@ name: Scheduled Rebuild
 
 on:
   schedule:
-    # First Monday of every month at 08:00 UTC
-    - cron: '0 8 1-7 * 1'
+    # 1st of every month at 08:00 UTC
+    - cron: '0 8 1 * *'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/scheduled-rebuild.yml
+++ b/.github/workflows/scheduled-rebuild.yml
@@ -1,0 +1,60 @@
+name: Scheduled Rebuild
+
+on:
+  schedule:
+    # First Monday of every month at 08:00 UTC
+    - cron: '0 8 1-7 * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: scheduled-rebuild
+  cancel-in-progress: false
+
+jobs:
+  rebuild:
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - major_version: v1
+            dockerfile: v1/Dockerfile
+            tags: |
+              gcr.io/instruqt/cloud-client:1
+              gcr.io/instruqt/cloud-client:latest
+          - major_version: v2
+            dockerfile: v2/Dockerfile
+            tags: |
+              gcr.io/instruqt/cloud-client:2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v3
+        with:
+          token_format: access_token
+          workload_identity_provider: ${{ secrets.GH_GCLOUD_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GH_GCLOUD_SERVICE_ACCOUNT }}
+
+      - name: Login to GCR
+        uses: docker/login-action@v4
+        with:
+          registry: gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+
+      - name: Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          file: ${{ matrix.dockerfile }}
+          tags: ${{ matrix.tags }}

--- a/.github/workflows/scheduled-rebuild.yml
+++ b/.github/workflows/scheduled-rebuild.yml
@@ -21,16 +21,24 @@ jobs:
         include:
           - major_version: v1
             dockerfile: v1/Dockerfile
-            tags: |
-              gcr.io/instruqt/cloud-client:1
-              gcr.io/instruqt/cloud-client:latest
+            latest: true
           - major_version: v2
             dockerfile: v2/Dockerfile
-            tags: |
-              gcr.io/instruqt/cloud-client:2
+            latest: false
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Generate tags
+        id: tags
+        run: |
+          DATE=$(date +%Y%m%d)
+          MAJOR="${{ matrix.major_version }}"
+          TAGS="gcr.io/instruqt/cloud-client:${MAJOR#v}-${DATE},gcr.io/instruqt/cloud-client:${MAJOR#v}"
+          if [[ "${{ matrix.latest }}" == "true" ]]; then
+            TAGS="${TAGS},gcr.io/instruqt/cloud-client:latest"
+          fi
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
 
       - name: Authenticate to Google Cloud
         id: auth
@@ -57,4 +65,4 @@ jobs:
           push: true
           platforms: linux/amd64
           file: ${{ matrix.dockerfile }}
-          tags: ${{ matrix.tags }}
+          tags: ${{ steps.tags.outputs.tags }}

--- a/v1/Dockerfile
+++ b/v1/Dockerfile
@@ -7,7 +7,10 @@ RUN apt-get update && apt-get upgrade -y && \
     curl -sL https://aka.ms/InstallAzureCLIDeb | bash && \
     curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null && \
     apt-get update && \
-    apt-get install --no-install-recommends -y curl vim apt-transport-https nano jq git groff nginx zip httpie google-cloud-sdk kubectl azure-cli && \
+    apt-get install --no-install-recommends -y curl vim apt-transport-https nano jq git groff nginx zip httpie google-cloud-sdk azure-cli && \
+    curl -LO "https://dl.k8s.io/release/v1.36.1/bin/linux/amd64/kubectl" && \
+    install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
+    rm kubectl && \
     rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     pip --no-cache-dir install awscli cfn-flip cfn-lint yamllint yq boto3 && \
     curl -o /usr/local/bin/gomplate -sSL https://github.com/hairyhenderson/gomplate/releases/download/v2.7.0/gomplate_linux-amd64 && \

--- a/v1/Dockerfile
+++ b/v1/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.14
 
+ARG KUBECTL_VERSION=v1.36.1
+
 RUN apt-get update && apt-get upgrade -y && \
     apt-get install --no-install-recommends -y curl lsb-release gnupg apt-utils && \
     curl -sS --fail -L https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
@@ -8,7 +10,7 @@ RUN apt-get update && apt-get upgrade -y && \
     curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null && \
     apt-get update && \
     apt-get install --no-install-recommends -y curl vim apt-transport-https nano jq git groff nginx zip httpie google-cloud-sdk azure-cli && \
-    curl -LO "https://dl.k8s.io/release/v1.36.1/bin/linux/amd64/kubectl" && \
+    curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
     install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
     rm kubectl && \
     rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* && \

--- a/v1/Dockerfile
+++ b/v1/Dockerfile
@@ -1,18 +1,14 @@
-FROM python:3.14
-
-ARG KUBECTL_VERSION=v1.36.1
+FROM python:3.14-trixie
 
 RUN apt-get update && apt-get upgrade -y && \
     apt-get install --no-install-recommends -y curl lsb-release gnupg apt-utils && \
-    curl -sS --fail -L https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -c -s) main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /etc/apt/keyrings/cloud.google.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -c -s) main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl -sL https://aka.ms/InstallAzureCLIDeb | bash && \
     curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null && \
     apt-get update && \
-    apt-get install --no-install-recommends -y curl vim apt-transport-https nano jq git groff nginx zip httpie google-cloud-sdk azure-cli && \
-    curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
-    install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
-    rm kubectl && \
+    apt-get install --no-install-recommends -y curl vim apt-transport-https nano jq git groff nginx zip httpie google-cloud-sdk kubectl azure-cli && \
     rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     pip --no-cache-dir install awscli cfn-flip cfn-lint yamllint yq boto3 && \
     curl -o /usr/local/bin/gomplate -sSL https://github.com/hairyhenderson/gomplate/releases/download/v2.7.0/gomplate_linux-amd64 && \

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -23,8 +23,13 @@ RUN apt-get update && apt-get upgrade -y && \
 RUN curl -sS https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -c -s) main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
     apt-get update && \
-    apt-get install --no-install-recommends -y kubectl google-cloud-sdk && \
+    apt-get install --no-install-recommends -y google-cloud-sdk && \
     rm -rf /var/lib/apt/lists/*
+
+# Install kubectl (pinned version, independent of Google Cloud SDK)
+RUN curl -LO "https://dl.k8s.io/release/v1.36.1/bin/linux/amd64/kubectl" && \
+    install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
+    rm kubectl
 
 # Install Azure CLI
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.14
 
+ARG KUBECTL_VERSION=v1.36.1
+
 # Update and install essential packages
 RUN apt-get update && apt-get upgrade -y && \
     apt-get install --no-install-recommends -y \
@@ -27,7 +29,7 @@ RUN curl -sS https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add
     rm -rf /var/lib/apt/lists/*
 
 # Install kubectl (pinned version, independent of Google Cloud SDK)
-RUN curl -LO "https://dl.k8s.io/release/v1.36.1/bin/linux/amd64/kubectl" && \
+RUN curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
     install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
     rm kubectl
 

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -1,6 +1,4 @@
-FROM python:3.14
-
-ARG KUBECTL_VERSION=v1.36.1
+FROM python:3.14-trixie
 
 # Update and install essential packages
 RUN apt-get update && apt-get upgrade -y && \
@@ -21,17 +19,13 @@ RUN apt-get update && apt-get upgrade -y && \
         zip && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Google Cloud SDK
-RUN curl -sS https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -c -s) main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
+# Install Google Cloud SDK and kubectl
+RUN mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /etc/apt/keyrings/cloud.google.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -c -s) main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
     apt-get update && \
-    apt-get install --no-install-recommends -y google-cloud-sdk && \
+    apt-get install --no-install-recommends -y google-cloud-sdk kubectl && \
     rm -rf /var/lib/apt/lists/*
-
-# Install kubectl (pinned version, independent of Google Cloud SDK)
-RUN curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
-    install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
-    rm kubectl
 
 # Install Azure CLI
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash


### PR DESCRIPTION
## Summary
- Replace deprecated `apt-key add` with modern `/etc/apt/keyrings` + `signed-by` approach in both v1 and v2 Dockerfiles
- Pin base image to `python:3.14-trixie` so Debian version upgrades don't silently break builds
- Keep `kubectl` installed from the Google Cloud SDK apt repo (unpinned) — monthly rebuilds pick up the latest version
- Add monthly scheduled rebuild workflow (1st of each month) to keep images fresh
- Add date-based tags (e.g. `1-20260601`) to scheduled rebuilds for rollback support

## Context
`python:3.14` moved from Debian Bookworm to Trixie, which removed `apt-key`. This broke fresh Docker builds. The fix uses the modern keyring approach (`gpg --dearmor` + `signed-by=`), which is the Debian-recommended way to scope GPG keys to specific repos.

Pinning to `python:3.14-trixie` prevents future surprise base image changes. kubectl stays unpinned in apt since a monthly rebuild keeps it current — verified locally at `v1.35.3-dispatcher`.

### Tagging strategy
- **Release workflow** (`v*.*.*` tags): creates semver tags (`:1.3.9`, `:1.3`, `:1`, `:latest`)
- **Scheduled rebuild** (monthly): overwrites rolling tags (`:1`, `:2`, `:latest`) and creates date tags (`:1-YYYYMMDD`, `:2-YYYYMMDD`) for rollback

### Post-merge action
Retag existing images with last month's date before the first scheduled rebuild runs:
```bash
gcloud container images add-tag gcr.io/instruqt/cloud-client:1 gcr.io/instruqt/cloud-client:1-20260501
gcloud container images add-tag gcr.io/instruqt/cloud-client:2 gcr.io/instruqt/cloud-client:2-20260501
```

## Test plan
- [x] Build v1 image locally — succeeds
- [x] Build v2 image locally — succeeds
- [x] `kubectl version --client` reports `v1.35.3-dispatcher`
- [x] All installed tools verified (gcloud, az, aws, jq, vim, nginx, gomplate)
- [ ] Verify scheduled rebuild workflow can be triggered manually
- [ ] Retag existing images with `*-20260501` date tags